### PR TITLE
Invert parameters in EmitterStack

### DIFF
--- a/config/routing-expressive.xml
+++ b/config/routing-expressive.xml
@@ -47,10 +47,10 @@
         <service id="Zend\HttpHandlerRunner\Emitter\SapiStreamEmitter" />
         <service id="Zend\HttpHandlerRunner\Emitter\EmitterStack">
             <call method="push">
-                <argument type="service" id="Zend\HttpHandlerRunner\Emitter\SapiStreamEmitter" />
+                <argument type="service" id="Zend\HttpHandlerRunner\Emitter\SapiEmitter" />
             </call>
             <call method="push">
-                <argument type="service" id="Zend\HttpHandlerRunner\Emitter\SapiEmitter" />
+                <argument type="service" id="Zend\HttpHandlerRunner\Emitter\SapiStreamEmitter" />
             </call>
         </service>
 


### PR DESCRIPTION
In order to handle stream and non-stream responses Zend Expressive needs
to first try with the SapiStreamEmitter and then the SapiEmitter, since
the latter does not check and simply echo's data.

Since the implementation is a stack, the reading order is inverted, this
we need to insert the stream emitter last, not first.