### PR TITLE
Rename route "type" to "behavior"

### DIFF
--- a/src/Mapping/ExpandTags.php
+++ b/src/Mapping/ExpandTags.php
@@ -19,7 +19,7 @@ use function is_array;
 
 final class ExpandTags implements CompilerPassInterface
 {
-    private const ROUTE_TYPES = [
+    private const ROUTE_BEHAVIOR = [
         Mapping\Routing\CreateEndpoint::class          => 'create',
         Mapping\Routing\CreateAndFetchEndpoint::class  => 'create_fetch',
         Mapping\Routing\ExecuteEndpoint::class         => 'execute',
@@ -103,10 +103,10 @@ final class ExpandTags implements CompilerPassInterface
             return $attributes;
         }
 
-        $type = self::ROUTE_TYPES[get_class($annotation)];
+        $type = self::ROUTE_BEHAVIOR[get_class($annotation)];
 
-        $attributes['type']    = $type;
-        $attributes['methods'] = implode(',', $attributes['methods'] ?? []);
+        $attributes['behavior'] = $type;
+        $attributes['methods']  = implode(',', $attributes['methods'] ?? []);
 
         if (isset($attributes['name'])) {
             $attributes['route_name'] = $attributes['name'];

--- a/src/Routing/Expressive/RegisterServices.php
+++ b/src/Routing/Expressive/RegisterServices.php
@@ -58,7 +58,7 @@ final class RegisterServices implements CompilerPassInterface
     private const MESSAGE_INVALID_ROUTE = 'You must specify the "route_name", "path", and "type" arguments in '
                                           . '"%s" (tag "%s").';
 
-    private const TYPES = [
+    private const BEHAVIORS = [
         'fetch'         => ['methods' => ['GET'], 'callback' => 'fetchOnly'],
         'create'        => ['methods' => ['POST'], 'callback' => 'createOnly'],
         'create_fetch'  => ['methods' => ['POST'], 'callback' => 'createAndFetch'],
@@ -221,7 +221,7 @@ final class RegisterServices implements CompilerPassInterface
         $services = [];
 
         foreach ($routes as $route) {
-            $services[] = $this->{self::TYPES[$route['type']]['callback']}(
+            $services[] = $this->{self::BEHAVIORS[$route['behavior']]['callback']}(
                 $this->applicationName . '.http.route.' . $route['route_name'],
                 $route,
                 $container
@@ -324,7 +324,7 @@ final class RegisterServices implements CompilerPassInterface
                 [
                     $route['path'],
                     new Reference($this->applicationName . '.http.route.' . $route['route_name']),
-                    $route['methods'] ?? self::TYPES[$route['type']]['methods'],
+                    $route['methods'] ?? self::BEHAVIORS[$route['behavior']]['methods'],
                     $route['route_name'],
                 ]
             );


### PR DESCRIPTION
Since we have plans to allow people to register services that are already a PSR-15 request handler, this is a more explicit name for the attribute.