### PR TITLE
Add new tag to inject error handler middlewares

### DIFF
--- a/src/Tags.php
+++ b/src/Tags.php
@@ -10,8 +10,9 @@ interface Tags
     public const BUS_COMMAND_HANDLER = 'chimera.command_handler';
     public const BUS_QUERY_HANDLER   = 'chimera.query_handler';
 
-    public const HTTP_MIDDLEWARE = 'chimera.http_middleware';
-    public const HTTP_ROUTE      = 'chimera.http_route';
+    public const HTTP_ERROR_HANDLING = 'chimera.http_error_handling';
+    public const HTTP_MIDDLEWARE     = 'chimera.http_middleware';
+    public const HTTP_ROUTE          = 'chimera.http_route';
 
     public const CONTENT_FORMATTER = 'chimera.content_negotiation';
 }


### PR DESCRIPTION
The goal of adding this optional tag is to position middlewares for
error handling as early as possible in the http pipeline.

Solves the main motivation behind the issue https://github.com/chimeraphp/di-symfony/issues/34