### PR TITLE
No longer allow registering multiple applications

### DIFF
--- a/src/Routing/Expressive/RegisterServices.php
+++ b/src/Routing/Expressive/RegisterServices.php
@@ -8,6 +8,7 @@ use Chimera\ExecuteCommand;
 use Chimera\ExecuteQuery;
 use Chimera\IdentifierGenerator;
 use Chimera\MessageCreator;
+use Chimera\Routing\Application as ApplicationInterface;
 use Chimera\Routing\Expressive\Application;
 use Chimera\Routing\Expressive\UriGenerator;
 use Chimera\Routing\Handler\CreateAndFetch;
@@ -22,6 +23,7 @@ use Lcobucci\ContentNegotiation\ContentTypeMiddleware;
 use Lcobucci\ContentNegotiation\Formatter\Json;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -416,6 +418,14 @@ final class RegisterServices implements CompilerPassInterface
         $app->setPublic(true);
 
         $container->setDefinition($this->applicationName . '.http', $app);
+
+        // --- alias application
+
+        if ($container->hasAlias(ApplicationInterface::class)) {
+            throw new InvalidArgumentException('There can only be one application registered.');
+        }
+
+        $container->setAlias(ApplicationInterface::class, new Alias($this->applicationName . '.http', true));
     }
 
     private function generateReadAction(string $name, string $query, ContainerBuilder $container): Reference

--- a/tests/Unit/Routing/Expressive/RegisterServicesTest.php
+++ b/tests/Unit/Routing/Expressive/RegisterServicesTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Chimera\DependencyInjection\Tests\Unit\Routing\Expressive;
+
+use Chimera\DependencyInjection\Routing\Expressive\RegisterServices;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+final class RegisterServicesTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function registeringServicesDoesNotAllowMultipleApplications(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $container = new ContainerBuilder();
+
+        $this->createRegisterServices('testing1')->process($container);
+        $this->createRegisterServices('testing2')->process($container);
+    }
+
+    private function createRegisterServices(string $applicationName): RegisterServices
+    {
+        return new RegisterServices(
+            $applicationName,
+            $applicationName . '.command_bus',
+            $applicationName . '.query_bus'
+        );
+    }
+}


### PR DESCRIPTION
Closes https://github.com/chimeraphp/di-symfony/issues/38

In order to simplify the container generation process, let's stop allowing the registration of multiple apps in a container and stick to a single one.

A side effect of these changes is that we can statically create the XML files for the services created in the compiler passes. We looked into it but we couldn't do it in a time-efficient manner.