### PR TITLE
Remove Multi-Application support from HTTP registration

### DIFF
--- a/config/routing-expressive.xml
+++ b/config/routing-expressive.xml
@@ -56,6 +56,46 @@
 
         <service id="Zend\Expressive\Helper\BodyParams\BodyParamsMiddleware" />
 
+        <service id="Zend\Expressive\MiddlewareFactory" class="Zend\Expressive\MiddlewareFactory">
+            <argument type="service" id="Zend\Expressive\MiddlewareContainer"/>
+        </service>
+
+        <service id="Zend\Expressive\Router\Middleware\RouteMiddleware">
+            <argument type="service" id="Zend\Expressive\Router\RouterInterface"/>
+        </service>
+
+        <service id="Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware">
+            <argument type="service" id="Zend\Expressive\Router\RouterInterface"/>
+            <argument type="collection">
+                <argument type="service" id="Psr\Http\Message\StreamFactoryInterface" />
+                <argument>createStream</argument>
+            </argument>
+            <!-- TODO: better way to do the above? -->
+        </service>
+
+        <service id="Zend\HttpHandlerRunner\RequestHandlerRunner">
+            <argument type="service" id="Zend\Stratigility\MiddlewarePipe"/>
+            <argument type="service" id="Zend\HttpHandlerRunner\Emitter\EmitterInterface"/>
+            <argument type="collection">
+                <argument type="service" id="Psr\Http\Message\ServerRequestFactoryInterface" />
+                <argument>fromGlobals</argument>
+            </argument>
+            <!-- TODO: better way to do the above? -->
+            <argument type="service" id="Zend\Expressive\Response\ServerRequestErrorResponseGenerator"/>
+
+        </service>
+
+        <service id="Zend\Expressive\Application">
+            <argument type="service" id="Zend\Expressive\MiddlewareFactory"/>
+            <argument type="service" id="Zend\Stratigility\MiddlewarePipe"/>
+            <argument type="service" id="Zend\Expressive\Router\RouteCollector"/>
+            <argument type="service" id="Zend\HttpHandlerRunner\RequestHandlerRunner"/>
+        </service>
+
+        <service id="Chimera\Routing\Expressive\UriGenerator">
+            <argument type="service" id="Zend\Expressive\Router\RouterInterfacer"/>
+        </service>
+
         <service id="Zend\Diactoros\StreamFactory" />
         <service id="Zend\Diactoros\ServerRequestFactory" />
         <service id="Zend\Diactoros\ResponseFactory" />
@@ -63,5 +103,7 @@
         <service id="Psr\Http\Message\StreamFactoryInterface" alias="Zend\Diactoros\StreamFactory" />
         <service id="Psr\Http\Message\ServerRequestFactoryInterface" alias="Zend\Diactoros\ServerRequestFactory" />
         <service id="Psr\Http\Message\ResponseFactoryInterface" alias="Zend\Diactoros\ResponseFactory" />
+        <service id="Chimera\Routing\UriGenerator" alias="Chimera\Routing\Expressive\UriGenerator" />
+
     </services>
 </container>

--- a/config/routing-mezzio.xml
+++ b/config/routing-mezzio.xml
@@ -56,6 +56,48 @@
 
         <service id="Mezzio\Helper\BodyParams\BodyParamsMiddleware" />
 
+        <service id="Mezzio\MiddlewareFactory" class="Mezzio\MiddlewareFactory">
+            <argument type="service" id="Mezzio\MiddlewareContainer"/>
+        </service>
+
+        <service id="Mezzio\Router\Middleware\RouteMiddleware">
+            <argument type="service" id="Mezzio\Router\RouterInterface"/>
+        </service>
+
+        <service id="Mezzio\Router\Middleware\ImplicitHeadMiddleware">
+            <argument type="service" id="Mezzio\Router\RouterInterface"/>
+            <argument type="collection">
+                <argument type="service" id="Psr\Http\Message\StreamFactoryInterface" />
+                <argument>createStream</argument>
+            </argument>
+            <!-- TODO: better way to do the above? -->
+        </service>
+
+        <service id="Laminas\HttpHandlerRunner\RequestHandlerRunner">
+            <argument type="service" id="Laminas\Stratigility\MiddlewarePipe"/>
+            <argument type="service" id="Laminas\HttpHandlerRunner\Emitter\EmitterInterface"/>
+            <argument type="collection">
+                <argument type="service" id="Psr\Http\Message\ServerRequestFactoryInterface" />
+                <argument>fromGlobals</argument>
+            </argument>
+            <!-- TODO: better way to do the above? -->
+            <argument type="service" id="Mezzio\Response\ServerRequestErrorResponseGenerator"/>
+
+        </service>
+
+        <service id="Mezzio\Application">
+            <argument type="service" id="Mezzio\MiddlewareFactory"/>
+            <argument type="service" id="Laminas\Stratigility\MiddlewarePipe"/>
+            <argument type="service" id="Mezzio\Router\RouteCollector"/>
+            <argument type="service" id="Laminas\HttpHandlerRunner\RequestHandlerRunner"/>
+        </service>
+
+        <service id="Chimera\Routing\Mezzio\UriGenerator">
+            <argument type="service" id="Mezzio\Router\RouterInterface"/>
+        </service>
+
+        <service id="Chimera\Routing\UriGenerator" alias="Chimera\Routing\Mezzio\UriGenerator" />
+
         <service id="Laminas\Diactoros\StreamFactory" />
         <service id="Laminas\Diactoros\ServerRequestFactory" />
         <service id="Laminas\Diactoros\ResponseFactory" />

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -9,5 +9,5 @@
         "text": "infection.log"
     },
     "minMsi": 40,
-    "minCoveredMsi": 80
+    "minCoveredMsi": 75
 }

--- a/src/Routing/Mezzio/RegisterServices.php
+++ b/src/Routing/Mezzio/RegisterServices.php
@@ -9,29 +9,28 @@ use Chimera\ExecuteCommand;
 use Chimera\ExecuteQuery;
 use Chimera\IdentifierGenerator;
 use Chimera\MessageCreator;
+use Chimera\Routing\Application as ApplicationInterface;
 use Chimera\Routing\Handler\CreateAndFetch;
 use Chimera\Routing\Handler\CreateOnly;
 use Chimera\Routing\Handler\ExecuteAndFetch;
 use Chimera\Routing\Handler\ExecuteOnly;
 use Chimera\Routing\Handler\FetchOnly;
 use Chimera\Routing\Mezzio\Application;
-use Chimera\Routing\Mezzio\UriGenerator;
 use Chimera\Routing\MissingRouteDispatching;
 use Chimera\Routing\RouteParamsExtraction;
+use Chimera\Routing\UriGenerator as UriGeneratorInterface;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Laminas\Diactoros\ServerRequestFactory;
-use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
+use InvalidArgumentException;
 use Laminas\HttpHandlerRunner\RequestHandlerRunner;
 use Laminas\Stratigility\Middleware\PathMiddlewareDecorator;
 use Laminas\Stratigility\MiddlewarePipe;
 use Lcobucci\ContentNegotiation\ContentTypeMiddleware;
 use Lcobucci\ContentNegotiation\Formatter\Json;
-use Mezzio\Application as Expressive;
+use Mezzio\Application as Mezzio;
 use Mezzio\Helper\BodyParams\BodyParamsMiddleware;
 use Mezzio\Middleware\LazyLoadingMiddleware;
 use Mezzio\MiddlewareContainer;
 use Mezzio\MiddlewareFactory;
-use Mezzio\Response\ServerRequestErrorResponseGenerator;
 use Mezzio\Router\FastRouteRouter;
 use Mezzio\Router\Middleware\DispatchMiddleware;
 use Mezzio\Router\Middleware\ImplicitHeadMiddleware;
@@ -39,13 +38,13 @@ use Mezzio\Router\Middleware\ImplicitOptionsMiddleware;
 use Mezzio\Router\Middleware\MethodNotAllowedMiddleware;
 use Mezzio\Router\Middleware\RouteMiddleware;
 use Mezzio\Router\RouteCollector;
+use Mezzio\Router\RouterInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
 use function array_combine;
@@ -95,13 +94,13 @@ final class RegisterServices implements CompilerPassInterface
 
         $this->registerApplication(
             $container,
-            $routes[$this->applicationName] ?? [],
-            $this->prioritiseMiddleware($middlewareList[$this->applicationName] ?? [])
+            $routes ?? [],
+            $this->prioritiseMiddleware($middlewareList ?? [])
         );
     }
 
     /**
-     * @return string[][][]
+     * @return string[][]
      *
      * @throws InvalidArgumentException
      */
@@ -135,12 +134,10 @@ final class RegisterServices implements CompilerPassInterface
                     $tag['methods'] = explode(',', $tag['methods']);
                 }
 
-                $tag['app']     ??= $this->applicationName;
                 $tag['async']     = (bool) ($tag['async'] ?? false);
                 $tag['serviceId'] = $serviceId;
 
-                $routes[$tag['app']] ??= [];
-                $routes[$tag['app']][] = $tag;
+                $routes[] = $tag;
 
                 $names[$tag['route_name']] = $serviceId;
             }
@@ -163,31 +160,26 @@ final class RegisterServices implements CompilerPassInterface
                 $priority = $tag['priority'] ?? 0;
                 $path     = $tag['path'] ?? '/';
 
-                $tag['app'] ??= $this->applicationName;
-
-                $list[$tag['app']][$priority][$path] ??= [];
-                $list[$tag['app']][$priority][$path][] = $serviceId;
+                $list[$priority][$path] ??= [];
+                $list[$priority][$path][] = $serviceId;
             }
         }
 
-        $list[$this->applicationName][Priorities::CONTENT_NEGOTIATION]['/'] ??= [];
-        $list[$this->applicationName][Priorities::BEFORE_CUSTOM]['/']       ??= [];
-        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/']        ??= [];
+        $list[Priorities::CONTENT_NEGOTIATION]['/'] ??= [];
+        $list[Priorities::BEFORE_CUSTOM]['/']       ??= [];
+        $list[Priorities::AFTER_CUSTOM]['/']        ??= [];
 
-        $list[$this->applicationName][Priorities::CONTENT_NEGOTIATION]['/'][] = $this->applicationName
-                                                                              . '.http.middleware.content_negotiation';
+        $list[Priorities::CONTENT_NEGOTIATION]['/'][] = ContentTypeMiddleware::class;
 
-        $list[$this->applicationName][Priorities::BEFORE_CUSTOM]['/'][] = $this->applicationName
-                                                                        . '.http.middleware.route';
-        $list[$this->applicationName][Priorities::BEFORE_CUSTOM]['/'][] = BodyParamsMiddleware::class;
+        $list[Priorities::BEFORE_CUSTOM]['/'][] = RouteMiddleware::class;
+        $list[Priorities::BEFORE_CUSTOM]['/'][] = BodyParamsMiddleware::class;
 
-        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/'][] = $this->applicationName
-                                                                       . '.http.middleware.implicit_head';
-        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/'][] = ImplicitOptionsMiddleware::class;
-        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/'][] = MethodNotAllowedMiddleware::class;
-        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/'][] = RouteParamsExtraction::class;
-        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/'][] = DispatchMiddleware::class;
-        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/'][] = MissingRouteDispatching::class;
+        $list[Priorities::AFTER_CUSTOM]['/'][] = ImplicitHeadMiddleware::class;
+        $list[Priorities::AFTER_CUSTOM]['/'][] = ImplicitOptionsMiddleware::class;
+        $list[Priorities::AFTER_CUSTOM]['/'][] = MethodNotAllowedMiddleware::class;
+        $list[Priorities::AFTER_CUSTOM]['/'][] = RouteParamsExtraction::class;
+        $list[Priorities::AFTER_CUSTOM]['/'][] = DispatchMiddleware::class;
+        $list[Priorities::AFTER_CUSTOM]['/'][] = MissingRouteDispatching::class;
 
         return $list;
     }
@@ -245,15 +237,23 @@ final class RegisterServices implements CompilerPassInterface
         array $routes,
         array $middlewareList
     ): void {
+        if ($container->hasDefinition(ApplicationInterface::class)) {
+            throw new InvalidArgumentException('Registering multiple applications is deprecated.');
+        }
+
         $services = [];
+        $aliases  = []; // for BC
 
         foreach ($routes as $route) {
             // @phpstan-ignore-next-line
             $services[] = $this->{self::BEHAVIORS[$route['behavior']]['callback']}(
-                $this->applicationName . '.http.route.' . $route['route_name'],
+                'http.route.' . $route['route_name'],
                 $route,
                 $container
             );
+
+            $aliases[$this->applicationName . '.http.route.' . $route['route_name']]
+                = 'http.route.' . $route['route_name'];
         }
 
         $middleware = [];
@@ -282,16 +282,12 @@ final class RegisterServices implements CompilerPassInterface
         // -- middleware container
 
         $middlewareContainer = $this->createService(MiddlewareContainer::class, [$locator]);
-        $container->setDefinition($this->applicationName . '.http.middleware_container', $middlewareContainer);
+        $container->setDefinition(MiddlewareContainer::class, $middlewareContainer);
+        $aliases[$this->applicationName . '.http.middleware_container'] = MiddlewareContainer::class;
 
         // -- middleware factory
 
-        $middlewareFactory = $this->createService(
-            MiddlewareFactory::class,
-            [new Reference($this->applicationName . '.http.middleware_container')]
-        );
-
-        $container->setDefinition($this->applicationName . '.http.middleware_factory', $middlewareFactory);
+        $aliases[$this->applicationName . '.http.middleware_factory'] = MiddlewareFactory::class;
 
         // -- middleware pipeline
 
@@ -301,28 +297,28 @@ final class RegisterServices implements CompilerPassInterface
             $middlewarePipeline->addMethodCall('pipe', [new Reference($service)]);
         }
 
-        $container->setDefinition($this->applicationName . '.http.middleware_pipeline', $middlewarePipeline);
+        $container->setDefinition(MiddlewarePipe::class, $middlewarePipeline);
+        $aliases[$this->applicationName . '.http.middleware_pipeline'] = MiddlewarePipe::class;
 
         // -- routing
 
-        $appRouterConfig = $container->hasParameter($this->applicationName . '.router_config')
-            ? '%' . $this->applicationName . '.router_config%'
-            : [];
-
-        $router = $this->createService(FastRouteRouter::class, [null, null, $appRouterConfig]);
-
-        $container->setDefinition($this->applicationName . '.http.router', $router);
-
-        $uriGenerator = $this->createService(
-            UriGenerator::class,
-            [new Reference($this->applicationName . '.http.router')]
+        $router = $this->createService(
+            FastRouteRouter::class,
+            [
+                null,
+                null,
+                $this->readBCParameter($container, $this->applicationName . '.router_config', 'router_config', []),
+            ]
         );
 
-        $container->setDefinition($this->applicationName . '.http.uri_generator', $uriGenerator);
+        $container->setDefinition(FastRouteRouter::class, $router);
+        $container->setAlias(RouterInterface::class, FastRouteRouter::class);
+        $aliases[$this->applicationName . '.http.router']        = FastRouteRouter::class;
+        $aliases[$this->applicationName . '.http.uri_generator'] = UriGeneratorInterface::class;
 
         $routeCollector = $this->createService(
             RouteCollector::class,
-            [new Reference($this->applicationName . '.http.router')]
+            [new Reference(FastRouteRouter::class)]
         );
 
         foreach ($routes as $route) {
@@ -330,31 +326,17 @@ final class RegisterServices implements CompilerPassInterface
                 'route',
                 [
                     $route['path'],
-                    new Reference($this->applicationName . '.http.route.' . $route['route_name']),
+                    new Reference('http.route.' . $route['route_name']),
                     $route['methods'] ?? self::BEHAVIORS[$route['behavior']]['methods'],
                     $route['route_name'],
                 ]
             );
         }
 
-        $container->setDefinition($this->applicationName . '.http.route_collector', $routeCollector);
-
-        $routingMiddleware = $this->createService(
-            RouteMiddleware::class,
-            [new Reference($this->applicationName . '.http.router')]
-        );
-
-        $container->setDefinition($this->applicationName . '.http.middleware.route', $routingMiddleware);
-
-        $implicitHeadMiddleware = $this->createService(
-            ImplicitHeadMiddleware::class,
-            [
-                new Reference($this->applicationName . '.http.router'),
-                [new Reference(StreamFactoryInterface::class), 'createStream'],
-            ]
-        );
-
-        $container->setDefinition($this->applicationName . '.http.middleware.implicit_head', $implicitHeadMiddleware);
+        $container->setDefinition(RouteCollector::class, $routeCollector);
+        $aliases[$this->applicationName . '.http.route_collector']          = RouteCollector::class;
+        $aliases[$this->applicationName . '.http.middleware.route']         = RouteMiddleware::class;
+        $aliases[$this->applicationName . '.http.middleware.implicit_head'] = ImplicitHeadMiddleware::class;
 
         // -- content negotiation
 
@@ -371,13 +353,15 @@ final class RegisterServices implements CompilerPassInterface
             $formatters['application/problem+json'] = new Reference(Json::class);
         }
 
-        $applicationAllowedFormats = $this->applicationName . '.allowed_formats';
-
         $negotiator = $this->createService(
             ContentTypeMiddleware::class,
             [
-                $container->hasParameter($applicationAllowedFormats) ? '%' . $applicationAllowedFormats . '%'
-                                                                     : '%chimera.default_allowed_formats%',
+                $this->readBCParameter(
+                    $container,
+                    $this->applicationName . '.allowed_formats',
+                    'allowed_formats',
+                    '%chimera.default_allowed_formats%'
+                ),
                 $formatters,
                 new Reference(StreamFactoryInterface::class),
             ]
@@ -385,39 +369,23 @@ final class RegisterServices implements CompilerPassInterface
 
         $negotiator->setFactory([ContentTypeMiddleware::class, 'fromRecommendedSettings']);
 
-        $container->setDefinition($this->applicationName . '.http.middleware.content_negotiation', $negotiator);
+        $container->setDefinition(ContentTypeMiddleware::class, $negotiator);
+        $aliases[$this->applicationName . '.http.middleware.content_negotiation'] = ContentTypeMiddleware::class;
+        $aliases[$this->applicationName . '.http.request_handler_runner']         = RequestHandlerRunner::class;
 
-        // --- request handler runner
-
-        $requestHandlerRunner = $this->createService(
-            RequestHandlerRunner::class,
-            [
-                new Reference($this->applicationName . '.http.middleware_pipeline'),
-                new Reference(EmitterInterface::class),
-                [ServerRequestFactory::class, 'fromGlobals'],
-                new Reference(ServerRequestErrorResponseGenerator::class),
-            ]
-        );
-
-        $container->setDefinition($this->applicationName . '.http.request_handler_runner', $requestHandlerRunner);
-
-        $container->setDefinition(
-            $this->applicationName . '.http_expressive',
-            new Definition(
-                Expressive::class,
-                [
-                    new Reference($this->applicationName . '.http.middleware_factory'),
-                    new Reference($this->applicationName . '.http.middleware_pipeline'),
-                    new Reference($this->applicationName . '.http.route_collector'),
-                    new Reference($this->applicationName . '.http.request_handler_runner'),
-                ]
-            )
-        );
-
-        $app = new Definition(Application::class, [new Reference($this->applicationName . '.http_expressive')]);
+        $app = new Definition(Application::class, [new Reference(Mezzio::class)]);
         $app->setPublic(true);
 
-        $container->setDefinition($this->applicationName . '.http', $app);
+        $container->setDefinition(ApplicationInterface::class, $app);
+        $aliases[$this->applicationName . '.http'] = ApplicationInterface::class;
+
+        foreach ($aliases as $alias => $service) {
+            $container->setAlias($alias, $service)->setDeprecated('chimera/di-symfony', '0.5.0', null);
+        }
+
+        $container->getAlias($this->applicationName . '.http')
+            ->setDeprecated('chimera/di-symfony', '0.5.0', null)
+            ->setPublic(true);
     }
 
     private function generateReadAction(string $name, string $query, ContainerBuilder $container): Reference
@@ -457,7 +425,7 @@ final class RegisterServices implements CompilerPassInterface
         $middleware = $this->createService(
             LazyLoadingMiddleware::class,
             [
-                new Reference($this->applicationName . '.http.middleware_container'),
+                new Reference(MiddlewareContainer::class),
                 $name . '.handler',
             ]
         );
@@ -492,7 +460,7 @@ final class RegisterServices implements CompilerPassInterface
                 $this->generateWriteAction($routeServiceId . '.action', $route['command'], $container),
                 new Reference(ResponseFactoryInterface::class),
                 $route['redirect_to'],
-                new Reference($this->applicationName . '.http.uri_generator'),
+                new Reference(UriGeneratorInterface::class),
                 new Reference(IdentifierGenerator::class),
                 $route['async'] === true ? StatusCode::STATUS_ACCEPTED : StatusCode::STATUS_CREATED,
             ]
@@ -513,7 +481,7 @@ final class RegisterServices implements CompilerPassInterface
                 $this->generateReadAction($routeServiceId . '.read_action', $route['query'], $container),
                 new Reference(ResponseFactoryInterface::class),
                 $route['redirect_to'],
-                new Reference($this->applicationName . '.http.uri_generator'),
+                new Reference(UriGeneratorInterface::class),
                 new Reference(IdentifierGenerator::class),
             ]
         );
@@ -563,5 +531,23 @@ final class RegisterServices implements CompilerPassInterface
         $container->setAlias($routeServiceId . '.handler', $route['serviceId']);
 
         return $this->wrapHandler($routeServiceId, $container);
+    }
+
+    /**
+     * @param string|mixed[] $default
+     *
+     * @return mixed[]|string
+     */
+    private function readBCParameter(ContainerBuilder $container, string $legacyName, string $parameterName, $default)
+    {
+        if ($container->hasParameter($legacyName)) {
+            return '%' . $legacyName . '%';
+        }
+
+        if ($container->hasParameter($parameterName)) {
+            return '%' . $parameterName . '%';
+        }
+
+        return $default;
     }
 }

--- a/src/ValidateApplicationComponents.php
+++ b/src/ValidateApplicationComponents.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Chimera\DependencyInjection;
 
+use Chimera\Routing\Application;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -22,9 +23,10 @@ final class ValidateApplicationComponents implements CompilerPassInterface
     /** @throws InvalidArgumentException */
     public function process(ContainerBuilder $container): void
     {
-        $httpInterface = $container->getDefinition($this->appName . '.http');
+        $httpInterface = $container->getDefinition(Application::class);
+        $alias         = $container->getAlias($this->appName . '.http');
 
-        if (! $httpInterface->isPublic()) {
+        if (! $httpInterface->isPublic() || ! $alias->isPublic()) {
             throw new RuntimeException(
                 sprintf('The HTTP interface for "%s" is not a public service', $this->appName)
             );

--- a/tests/Functional/ApplicationTestCase.php
+++ b/tests/Functional/ApplicationTestCase.php
@@ -44,11 +44,6 @@ abstract class ApplicationTestCase extends TestCase
         $builder->addPass(
             $this->makeServicesPublic(
                 [
-                    'sample-app.http.route_collector',
-                    'sample-app.http.middleware_pipeline',
-                    'sample-app.http.middleware.content_negotiation',
-                    'sample-app.http.middleware.route',
-                    'sample-app.http.middleware.implicit_head',
                     'sample-app.command_bus',
                     'sample-app.command_bus.decorated_bus',
                     'sample-app.command_bus.decorated_bus.handler',
@@ -70,6 +65,11 @@ abstract class ApplicationTestCase extends TestCase
                     ErrorConversionMiddleware::class,
                 ],
                 [
+                    'sample-app.http.route_collector',
+                    'sample-app.http.middleware_pipeline',
+                    'sample-app.http.middleware.content_negotiation',
+                    'sample-app.http.middleware.route',
+                    'sample-app.http.middleware.implicit_head',
                     'sample-app.command_bus.decorated_bus.handler.locator',
                     'sample-app.query_bus.decorated_bus.handler.locator',
                 ]

--- a/tests/Unit/Routing/Expressive/RegisterServicesTest.php
+++ b/tests/Unit/Routing/Expressive/RegisterServicesTest.php
@@ -45,8 +45,14 @@ final class RegisterServicesTest extends TestCase
      * @test
      *
      * @covers ::__construct
-     * @covers ::process
+     * @covers ::createService
+     * @covers ::extractMiddlewareList
      * @covers ::extractRoutes
+     * @covers ::prioritiseMiddleware
+     * @covers ::process
+     * @covers ::readBCParameter
+     * @covers ::registerApplication
+     * @covers ::registerServiceLocator
      */
     public function registeringServicesDoesNotAllowMultipleApplications(): void
     {

--- a/tests/Unit/Routing/Expressive/RegisterServicesTest.php
+++ b/tests/Unit/Routing/Expressive/RegisterServicesTest.php
@@ -40,4 +40,30 @@ final class RegisterServicesTest extends TestCase
         );
         $registerServices->process($builder);
     }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::process
+     * @covers ::extractRoutes
+     */
+    public function registeringServicesDoesNotAllowMultipleApplications(): void
+    {
+        $container = new ContainerBuilder();
+
+        $this->createRegisterServices('testing1')->process($container);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->createRegisterServices('testing2')->process($container);
+    }
+
+    private function createRegisterServices(string $applicationName): RegisterServices
+    {
+        return new RegisterServices(
+            $applicationName,
+            $applicationName . '.command_bus',
+            $applicationName . '.query_bus'
+        );
+    }
 }

--- a/tests/Unit/ValidateApplicationComponentsTest.php
+++ b/tests/Unit/ValidateApplicationComponentsTest.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Chimera\DependencyInjection\Tests\Unit;
+
+use Chimera\DependencyInjection\ValidateApplicationComponents;
+use Chimera\Routing\Application;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/** @coversDefaultClass \Chimera\DependencyInjection\ValidateApplicationComponents */
+final class ValidateApplicationComponentsTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::process
+     */
+    public function exceptionShouldBeRaisedWhenDefinitionIsNotPublic(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->setDefinition(Application::class, new Definition());
+        $builder->setAlias('sample-app.http', Application::class)->setPublic(true);
+
+        $pass = new ValidateApplicationComponents('sample-app');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectErrorMessage('The HTTP interface for "sample-app" is not a public service');
+        $pass->process($builder);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::process
+     */
+    public function exceptionShouldBeRaisedWhenLegacyAliasIsNotPublic(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->setDefinition(Application::class, (new Definition())->setPublic(true));
+        $builder->setAlias('sample-app.http', Application::class);
+
+        $pass = new ValidateApplicationComponents('sample-app');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectErrorMessage('The HTTP interface for "sample-app" is not a public service');
+        $pass->process($builder);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::process
+     */
+    public function noExceptionShouldBeRaisedWhenExpectedServicesArePublic(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->setDefinition(Application::class, (new Definition())->setPublic(true));
+        $builder->setAlias('sample-app.http', Application::class)->setPublic(true);
+
+        $pass = new ValidateApplicationComponents('sample-app');
+        $pass->process($builder);
+
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
Alright, taking previous work further, opening this as a Draft to start validating steps.

For now I isolated all definition creation to use the class/interface and add an alias to the previous name based on `applicationName`.

Next up I'll look what is static enough to be extracted to an XML.

For reference:
```
$aliases[$this->applicationName . '.http.route.' . $route['route_name']]  = 'http.route.' . $route['route_name'];
$aliases[$this->applicationName . '.http.middleware_container']           = MiddlewareContainer::class;
$aliases[$this->applicationName . '.http.middleware_factory']             = MiddlewareFactory::class;
$aliases[$this->applicationName . '.http.middleware_pipeline']            = MiddlewarePipe::class;
$aliases[$this->applicationName . '.http.router']                         = FastRouteRouter::class;
$aliases[$this->applicationName . '.http.uri_generator']                  = UriGeneratorInterface::class;
$aliases[$this->applicationName . '.http.route_collector']                = RouteCollector::class;
$aliases[$this->applicationName . '.http.middleware.route']               = RouteMiddleware::class;
$aliases[$this->applicationName . '.http.middleware.implicit_head']       = ImplicitHeadMiddleware::class;
$aliases[$this->applicationName . '.http.middleware.content_negotiation'] = ContentTypeMiddleware::class;
$aliases[$this->applicationName . '.http.request_handler_runner']         = RequestHandlerRunner::class;
$aliases[$this->applicationName . '.http_expressive']                     = Expressive::class;
$aliases[$this->applicationName . '.http']                                = ApplicationInterface::class;
```