### PR TITLE
Use simplified command handler

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1978,19 +1978,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/chimeraphp/bus-tactician.git",
-                "reference": "a0b732c0d10dcfda4e97f24d6d0b8c9794333bac"
+                "reference": "0134905077ad3be9367b4b188ba16fd4b994be63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/chimeraphp/bus-tactician/zipball/a0b732c0d10dcfda4e97f24d6d0b8c9794333bac",
-                "reference": "a0b732c0d10dcfda4e97f24d6d0b8c9794333bac",
+                "url": "https://api.github.com/repos/chimeraphp/bus-tactician/zipball/0134905077ad3be9367b4b188ba16fd4b994be63",
+                "reference": "0134905077ad3be9367b4b188ba16fd4b994be63",
                 "shasum": ""
             },
             "require": {
                 "chimera/foundation": "^0.4@dev",
-                "league/tactician": "^1.0",
-                "league/tactician-container": "^2.0",
-                "php": "^7.4 || ^8.0"
+                "league/tactician": "^1.1",
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0"
             },
             "provide": {
                 "chimera/bus-implementation": "0.4.0"
@@ -2007,11 +2007,6 @@
             },
             "default-branch": true,
             "type": "library",
-            "extra": {
-                "unused": [
-                    "league/tactician-container"
-                ]
-            },
             "autoload": {
                 "psr-4": {
                     "Chimera\\ServiceBus\\Tactician\\": "src"
@@ -2042,7 +2037,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-02-07T13:39:56+00:00"
+            "time": "2021-02-21T12:54:46+00:00"
         },
         {
             "name": "chimera/mapping",
@@ -2383,16 +2378,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.11.1",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad"
+                "reference": "ebec9b1708c95d7602245c8172773f6b4e0c3be1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
-                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/ebec9b1708c95d7602245c8172773f6b4e0c3be1",
+                "reference": "ebec9b1708c95d7602245c8172773f6b4e0c3be1",
                 "shasum": ""
             },
             "require": {
@@ -2407,11 +2402,6 @@
                 "phpunit/phpunit": "^7.5 || ^9.1.5"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
@@ -2452,9 +2442,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.11.1"
+                "source": "https://github.com/doctrine/annotations/tree/1.12.0"
             },
-            "time": "2020-10-26T10:28:16+00:00"
+            "time": "2021-02-14T13:22:18+00:00"
         },
         {
             "name": "doctrine/coding-standard",
@@ -3686,61 +3676,6 @@
             "time": "2021-02-14T15:29:04+00:00"
         },
         {
-            "name": "league/tactician-container",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/tactician-container.git",
-                "reference": "d1a5d884e072b8cafbff802d07766076eb2ffcb0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/tactician-container/zipball/d1a5d884e072b8cafbff802d07766076eb2ffcb0",
-                "reference": "d1a5d884e072b8cafbff802d07766076eb2ffcb0",
-                "shasum": ""
-            },
-            "require": {
-                "league/tactician": "^1.0",
-                "php": ">=5.5",
-                "psr/container": "^1.0"
-            },
-            "require-dev": {
-                "league/container": "~2.3",
-                "phpunit/phpunit": "~4.3",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "League\\Tactician\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nigel Greenway",
-                    "homepage": "http://futurepixels.co.uk"
-                }
-            ],
-            "description": "Tactician integration for any container implementing PSR-11",
-            "keywords": [
-                "container",
-                "container-interop",
-                "di",
-                "interoperable",
-                "league",
-                "tactician"
-            ],
-            "support": {
-                "issues": "https://github.com/thephpleague/tactician-container/issues",
-                "source": "https://github.com/thephpleague/tactician-container/tree/master"
-            },
-            "time": "2017-04-13T06:27:12+00:00"
-        },
-        {
             "name": "mezzio/mezzio",
             "version": "3.3.0",
             "source": {
@@ -4881,16 +4816,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.77",
+            "version": "0.12.78",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "1f10b8c8d118d01e7b492f9707999d456be5812c"
+                "reference": "eecce8d2ee3cac6769f37b4cb1998b2715f82984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1f10b8c8d118d01e7b492f9707999d456be5812c",
-                "reference": "1f10b8c8d118d01e7b492f9707999d456be5812c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/eecce8d2ee3cac6769f37b4cb1998b2715f82984",
+                "reference": "eecce8d2ee3cac6769f37b4cb1998b2715f82984",
                 "shasum": ""
             },
             "require": {
@@ -4921,7 +4856,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.77"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.78"
             },
             "funding": [
                 {
@@ -4937,7 +4872,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-17T16:22:19+00:00"
+            "time": "2021-02-20T13:24:36+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",

--- a/config/bus-tactician.xml
+++ b/config/bus-tactician.xml
@@ -5,14 +5,6 @@
     <services>
         <defaults public="false" />
 
-        <service id="League\Tactician\Handler\CommandNameExtractor\ClassNameExtractor" />
-
-        <service id="League\Tactician\Handler\MethodNameInflector\ClassNameInflector" />
-        <service id="League\Tactician\Handler\MethodNameInflector\HandleClassNameInflector" />
-        <service id="League\Tactician\Handler\MethodNameInflector\HandleClassNameWithoutSuffixInflector" />
-        <service id="League\Tactician\Handler\MethodNameInflector\HandleInflector" />
-        <service id="League\Tactician\Handler\MethodNameInflector\InvokeInflector" />
-
         <service id="Chimera\ServiceBus\Tactician\ReadModelConversionMiddleware">
             <argument type="service" id="Chimera\ServiceBus\ReadModelConverter" />
         </service>

--- a/tests/Functional/ApplicationRegistrationTest.php
+++ b/tests/Functional/ApplicationRegistrationTest.php
@@ -23,7 +23,7 @@ use Chimera\ServiceBus;
 use Chimera\ServiceBus\Tactician\ReadModelConversionMiddleware;
 use Laminas\Stratigility\MiddlewarePipe;
 use League\Tactician\CommandBus;
-use League\Tactician\Container\ContainerLocator;
+use League\Tactician\Handler\Locator\HandlerLocator;
 use League\Tactician\Middleware;
 use Mezzio\Helper\BodyParams\BodyParamsMiddleware;
 use Mezzio\Router\Middleware\DispatchMiddleware;
@@ -149,7 +149,7 @@ final class ApplicationRegistrationTest extends ApplicationTestCase
         $container = $this->createContainer();
 
         $locator = $container->get('sample-app.command_bus.decorated_bus.handler.locator');
-        assert($locator instanceof ContainerLocator);
+        assert($locator instanceof HandlerLocator);
 
         self::assertInstanceOf(CreateThingHandler::class, $locator->getHandlerForCommand(CreateThing::class));
         self::assertInstanceOf(RemoveThingHandler::class, $locator->getHandlerForCommand(RemoveThing::class));
@@ -179,7 +179,7 @@ final class ApplicationRegistrationTest extends ApplicationTestCase
         $container = $this->createContainer();
 
         $locator = $container->get('sample-app.query_bus.decorated_bus.handler.locator');
-        assert($locator instanceof ContainerLocator);
+        assert($locator instanceof HandlerLocator);
 
         self::assertInstanceOf(FetchThingHandler::class, $locator->getHandlerForCommand(FetchThing::class));
         self::assertInstanceOf(ListThingsHandler::class, $locator->getHandlerForCommand(ListThings::class));

--- a/tests/Functional/ApplicationTestCase.php
+++ b/tests/Functional/ApplicationTestCase.php
@@ -51,11 +51,9 @@ abstract class ApplicationTestCase extends TestCase
                     'sample-app.command_bus',
                     'sample-app.command_bus.decorated_bus',
                     'sample-app.command_bus.decorated_bus.handler',
-                    'sample-app.command_bus.decorated_bus.handler.locator',
                     'sample-app.query_bus',
                     'sample-app.query_bus.decorated_bus',
                     'sample-app.query_bus.decorated_bus.handler',
-                    'sample-app.query_bus.decorated_bus.handler.locator',
                     BodyParamsMiddleware::class,
                     ImplicitOptionsMiddleware::class,
                     MethodNotAllowedMiddleware::class,
@@ -69,7 +67,10 @@ abstract class ApplicationTestCase extends TestCase
                     QueryOnlyMiddleware::class,
                     CommandAndQueryMiddleware::class,
                 ],
-                []
+                [
+                    'sample-app.command_bus.decorated_bus.handler.locator',
+                    'sample-app.query_bus.decorated_bus.handler.locator',
+                ]
             ),
             PassConfig::TYPE_BEFORE_REMOVING
         );


### PR DESCRIPTION
This makes the application registration use a command handler provided by `chimera/bus-tactician`, which removes some method calls and allows us to name methods on handlers according to the needs - instead of forcing some convention...