### PR TITLE
Allow registration of custom middleware before any middleware

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -8,6 +8,6 @@
     "logs": {
         "text": "infection.log"
     },
-    "minMsi": 50,
-    "minCoveredMsi": 95
+    "minMsi": 40,
+    "minCoveredMsi": 90
 }

--- a/src/Routing/Mezzio/RegisterServices.php
+++ b/src/Routing/Mezzio/RegisterServices.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Chimera\DependencyInjection\Routing\Mezzio;
 
+use Chimera\DependencyInjection\Routing\Priorities;
 use Chimera\DependencyInjection\Tags;
 use Chimera\ExecuteCommand;
 use Chimera\ExecuteQuery;
@@ -144,12 +145,29 @@ final class RegisterServices implements CompilerPassInterface
 
                 $tag['app'] ??= $this->applicationName;
 
-                $list[$tag['app']]                   ??= [];
-                $list[$tag['app']][$priority]        ??= [];
                 $list[$tag['app']][$priority][$path] ??= [];
                 $list[$tag['app']][$priority][$path][] = $serviceId;
             }
         }
+
+        $list[$this->applicationName][Priorities::CONTENT_NEGOTIATION]['/'] ??= [];
+        $list[$this->applicationName][Priorities::BEFORE_CUSTOM]['/']       ??= [];
+        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/']        ??= [];
+
+        $list[$this->applicationName][Priorities::CONTENT_NEGOTIATION]['/'][] = $this->applicationName
+                                                                              . '.http.middleware.content_negotiation';
+
+        $list[$this->applicationName][Priorities::BEFORE_CUSTOM]['/'][] = $this->applicationName
+                                                                        . '.http.middleware.route';
+        $list[$this->applicationName][Priorities::BEFORE_CUSTOM]['/'][] = BodyParamsMiddleware::class;
+
+        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/'][] = $this->applicationName
+                                                                       . '.http.middleware.implicit_head';
+        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/'][] = ImplicitOptionsMiddleware::class;
+        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/'][] = MethodNotAllowedMiddleware::class;
+        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/'][] = RouteParamsExtraction::class;
+        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/'][] = DispatchMiddleware::class;
+        $list[$this->applicationName][Priorities::AFTER_CUSTOM]['/'][] = MissingRouteDispatching::class;
 
         return $list;
     }
@@ -258,26 +276,10 @@ final class RegisterServices implements CompilerPassInterface
         // -- middleware pipeline
 
         $middlewarePipeline = $this->createService(MiddlewarePipe::class);
-        $middlewarePipeline->addMethodCall(
-            'pipe',
-            [new Reference($this->applicationName . '.http.middleware.content_negotiation')]
-        );
-        $middlewarePipeline->addMethodCall('pipe', [new Reference($this->applicationName . '.http.middleware.route')]);
-        $middlewarePipeline->addMethodCall('pipe', [new Reference(BodyParamsMiddleware::class)]);
 
         foreach ($middleware as $service) {
             $middlewarePipeline->addMethodCall('pipe', [new Reference($service)]);
         }
-
-        $middlewarePipeline->addMethodCall(
-            'pipe',
-            [new Reference($this->applicationName . '.http.middleware.implicit_head')]
-        );
-        $middlewarePipeline->addMethodCall('pipe', [new Reference(ImplicitOptionsMiddleware::class)]);
-        $middlewarePipeline->addMethodCall('pipe', [new Reference(MethodNotAllowedMiddleware::class)]);
-        $middlewarePipeline->addMethodCall('pipe', [new Reference(RouteParamsExtraction::class)]);
-        $middlewarePipeline->addMethodCall('pipe', [new Reference(DispatchMiddleware::class)]);
-        $middlewarePipeline->addMethodCall('pipe', [new Reference(MissingRouteDispatching::class)]);
 
         $container->setDefinition($this->applicationName . '.http.middleware_pipeline', $middlewarePipeline);
 

--- a/src/Routing/Priorities.php
+++ b/src/Routing/Priorities.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Chimera\DependencyInjection\Routing;
+
+interface Priorities
+{
+    public const CONTENT_NEGOTIATION = 110;
+    public const BEFORE_CUSTOM       = 100;
+    public const AFTER_CUSTOM        = -100;
+}

--- a/tests/Functional/ApplicationTestCase.php
+++ b/tests/Functional/ApplicationTestCase.php
@@ -27,10 +27,10 @@ use function exec;
 abstract class ApplicationTestCase extends TestCase
 {
     /**
-     * @before
-     * @after
+     * @beforeClass
+     * @afterClass
      */
-    final public function cleanUpContainer(): void
+    final public static function cleanUpContainer(): void
     {
         exec('rm -rf ' . __DIR__ . '/App/dump');
     }


### PR DESCRIPTION
This allows users to register custom middleware before and/or after the ones provided by default.
    
To do so, they need to configure the priority of their middleware considering that Chimera will register the default using the following priorities:
    
* Content negotiation -> 110
* Routing + body parsing -> 100
* All other default ones -> -100
    
Closes https://github.com/chimeraphp/di-symfony/issues/4
