### PR TITLE
Prevent the registration of duplicated routes

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -9,5 +9,5 @@
         "text": "infection.log"
     },
     "minMsi": 40,
-    "minCoveredMsi": 90
+    "minCoveredMsi": 80
 }

--- a/src/Routing/Expressive/RegisterServices.php
+++ b/src/Routing/Expressive/RegisterServices.php
@@ -49,6 +49,7 @@ use Zend\Stratigility\Middleware\PathMiddlewareDecorator;
 use Zend\Stratigility\MiddlewarePipe;
 
 use function array_combine;
+use function array_key_exists;
 use function array_map;
 use function assert;
 use function explode;
@@ -60,6 +61,9 @@ final class RegisterServices implements CompilerPassInterface
 {
     private const MESSAGE_INVALID_ROUTE = 'You must specify the "route_name", "path", and "behavior" arguments in '
     . '"%s" (tag "%s").';
+
+    private const MESSAGE_DUPLICATED_ROUTE = 'The service "%s" is trying to declare a route with name "%s" which has '
+                                           . 'already been defined by the service "%s".';
 
     private const BEHAVIORS = [
         'fetch'         => ['methods' => ['GET'], 'callback' => 'fetchOnly'],
@@ -104,12 +108,26 @@ final class RegisterServices implements CompilerPassInterface
     private function extractRoutes(ContainerBuilder $container): array
     {
         $routes = [];
+        $names  = [];
 
         foreach ($container->findTaggedServiceIds(Tags::HTTP_ROUTE) as $serviceId => $tags) {
             foreach ($tags as $tag) {
                 if (! isset($tag['route_name'], $tag['path'], $tag['behavior'])) {
                     throw new InvalidArgumentException(
                         sprintf(self::MESSAGE_INVALID_ROUTE, $serviceId, Tags::HTTP_ROUTE)
+                    );
+                }
+
+                assert(is_string($tag['route_name']));
+
+                if (array_key_exists($tag['route_name'], $names)) {
+                    throw new InvalidArgumentException(
+                        sprintf(
+                            self::MESSAGE_DUPLICATED_ROUTE,
+                            $serviceId,
+                            $tag['route_name'],
+                            $names[$tag['route_name']]
+                        )
                     );
                 }
 
@@ -123,6 +141,8 @@ final class RegisterServices implements CompilerPassInterface
 
                 $routes[$tag['app']] ??= [];
                 $routes[$tag['app']][] = $tag;
+
+                $names[$tag['route_name']] = $serviceId;
             }
         }
 

--- a/tests/Unit/Routing/Expressive/RegisterServicesTest.php
+++ b/tests/Unit/Routing/Expressive/RegisterServicesTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Chimera\DependencyInjection\Tests\Unit\Routing\Expressive;
+
+use Chimera\DependencyInjection\Routing\Expressive\RegisterServices;
+use Chimera\DependencyInjection\Tags;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/** @coversDefaultClass \Chimera\DependencyInjection\Routing\Expressive\RegisterServices */
+final class RegisterServicesTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::process
+     * @covers ::extractRoutes
+     */
+    public function exceptionShouldBeRaisedWhenTryingToRegisterDuplicatedRoutes(): void
+    {
+        $service1 = new Definition();
+        $service1->addTag(Tags::HTTP_ROUTE, ['route_name' => 'test', 'path' => '/one', 'behavior' => 'fetch']);
+
+        $service2 = new Definition();
+        $service2->addTag(Tags::HTTP_ROUTE, ['route_name' => 'test', 'path' => '/two', 'behavior' => 'fetch']);
+
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions(['service1' => $service1, 'service2' => $service2]);
+
+        $registerServices = new RegisterServices('app', 'app.command-bus', 'app.query-bus');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The service "service2" is trying to declare a route with name "test" '
+            . 'which has already been defined by the service "service1".'
+        );
+        $registerServices->process($builder);
+    }
+}

--- a/tests/Unit/Routing/Mezzio/RegisterServicesTest.php
+++ b/tests/Unit/Routing/Mezzio/RegisterServicesTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Chimera\DependencyInjection\Tests\Unit\Routing\Mezzio;
+
+use Chimera\DependencyInjection\Routing\Mezzio\RegisterServices;
+use Chimera\DependencyInjection\Tags;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/** @coversDefaultClass \Chimera\DependencyInjection\Routing\Mezzio\RegisterServices */
+final class RegisterServicesTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::process
+     * @covers ::extractRoutes
+     */
+    public function exceptionShouldBeRaisedWhenTryingToRegisterDuplicatedRoutes(): void
+    {
+        $service1 = new Definition();
+        $service1->addTag(Tags::HTTP_ROUTE, ['route_name' => 'test', 'path' => '/one', 'behavior' => 'fetch']);
+
+        $service2 = new Definition();
+        $service2->addTag(Tags::HTTP_ROUTE, ['route_name' => 'test', 'path' => '/two', 'behavior' => 'fetch']);
+
+        $builder = new ContainerBuilder();
+        $builder->addDefinitions(['service1' => $service1, 'service2' => $service2]);
+
+        $registerServices = new RegisterServices('app', 'app.command-bus', 'app.query-bus');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The service "service2" is trying to declare a route with name "test" '
+            . 'which has already been defined by the service "service1".'
+        );
+        $registerServices->process($builder);
+    }
+}


### PR DESCRIPTION
This aims to prevent applications from misbehaving due to endpoints being silently overridden, caused by configuration mistakes.

Fixes https://github.com/chimeraphp/di-symfony/issues/39